### PR TITLE
Do not import R axioms

### DIFF
--- a/HeliosIACR2018.v
+++ b/HeliosIACR2018.v
@@ -11,7 +11,7 @@ Require Import Specif.
 Require Import Coq.PArith.Pnat.
 Require Import Coq.ZArith.Znat.
 Require Import ArithRing.
-Require Import Psatz. 
+Require Import Lia.
 Require Import Recdef.
 Require Import Div2.
 Require Import Coq.Arith.Wf_nat.


### PR DESCRIPTION
R(eals) axioms were imported but not used. With this commit, `coqchk` (when run on helios.vo and Extraction.vo) no longer returns spurious axioms in the context summary.